### PR TITLE
STORY-003 feat: Delete Events and Authentication

### DIFF
--- a/app/Events/EventDeleted.php
+++ b/app/Events/EventDeleted.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class EventDeleted implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $event;
+    /**
+     * Create a new event instance.
+     */
+    public function __construct($event)
+    {
+        $this->event = $event;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, \Illuminate\Broadcasting\Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('events'),
+        ];
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function broadcastAs(): string
+    {
+        return 'event.deleted';
+    }
+}

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -105,9 +105,22 @@ class EventController extends Controller
 
     /**
      * Remove the specified resource from storage.
+     *
+     * @param  string $id
+     * @return JsonResponse
      */
-    public function destroy(string $id)
+    public function destroy(string $id): JsonResponse
     {
-        //
+        try {
+            $this->eventService->delete($id);
+
+            return ApiResponse::success(
+                [],
+                'Event deleted successfully',
+                200
+            );
+        } catch (\Exception $e) {
+            return ApiResponse::error($e->getMessage());
+        }
     }
 }

--- a/app/Repositories/Contracts/EventRepositoryInterface.php
+++ b/app/Repositories/Contracts/EventRepositoryInterface.php
@@ -10,4 +10,5 @@ interface EventRepositoryInterface
     public function getAll(int $perPage, string $sortBy): Paginator;
     public function getById(int $id): array;
     public function update(array $data, int $id): array;
+    public function delete(int $id): void;
 }

--- a/app/Repositories/Eloquent/EventRepository.php
+++ b/app/Repositories/Eloquent/EventRepository.php
@@ -55,6 +55,7 @@ class EventRepository implements EventRepositoryInterface
      * @param  array $data
      * @param  int $id
      * @return array
+     * @throws \Exception
      */
     public function update(array $data, int $id): array
     {
@@ -67,6 +68,24 @@ class EventRepository implements EventRepositoryInterface
         $event->update($data);
 
         return $event->toArray();
+    }
+
+    /**
+     * only the owner of the event can delete it
+     *
+     * @param  int $id
+     * @return void
+     * @throws \Exception
+     */
+    public function delete(int $id): void
+    {
+        $event = Event::findOrFail($id);
+
+        if ($event->user_id !== auth()->id()) {
+            throw new \Exception("You are not authorized to delete this event.");
+        }
+
+        $event->delete();
     }
 
     /**

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Events\EventCreated;
+use App\Events\EventDeleted;
 use App\Events\EventUpdated;
 use App\Repositories\Contracts\EventRepositoryInterface;
 use Illuminate\Contracts\Pagination\Paginator;
@@ -63,5 +64,19 @@ class EventService
         broadcast(new EventUpdated($event))->toOthers();
 
         return $event;
+    }
+
+    /**
+     *
+     * @param  string $id
+     * @return void
+     */
+    public function delete(string $id): void
+    {
+        $event = $this->eventRepository->getById((int)$id);
+
+        $this->eventRepository->delete((int)$event['id']);
+
+        broadcast(new EventDeleted($event))->toOthers();
     }
 }

--- a/resources/js/components/dashboard/Dashboard.vue
+++ b/resources/js/components/dashboard/Dashboard.vue
@@ -31,5 +31,10 @@ const subscribeToPusherChannels = () => {
         eventBus.emit('event-updated', data.event);
         showEventUpdateToast(`Event "${data.event.title}" has been updated!`);
     });
+
+    channel.bind('event.deleted', (data) => {
+        eventBus.emit('event-deleted', data.event);
+        showEventUpdateToast(`Event "${data.event.title}" has been deleted!`);
+    });
 };
 </script>

--- a/resources/js/utils/notifications.js
+++ b/resources/js/utils/notifications.js
@@ -32,6 +32,19 @@ const eventUpdateToast = (icon, title, timer = 6000) => {
     });
 };
 
+const showConfirmationDialog = async (title, text, confirmButtonText = 'Yes, delete it!') => {
+    return Swal.fire({
+        title: title,
+        text: text,
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: confirmButtonText,
+        cancelButtonText: 'Cancel'
+    });
+};
+
 const showSuccessToast = (title, timer) => {
     showToast('success', title, timer);
 };
@@ -44,4 +57,4 @@ const showEventUpdateToast = (title, timer) => {
     eventUpdateToast('info', title, timer);
 };
 
-export { showSuccessToast, showErrorToast, showEventUpdateToast };
+export { showSuccessToast, showErrorToast, showEventUpdateToast, showConfirmationDialog };


### PR DESCRIPTION
### **CONTEXT:**
User needs to be able to delete events. Only owner user should be able to delete an event.

### **Changes:**
-Add ability to delete events.
-Dispatch notification when Event is deleted.

**Note:** As **_Sanctum_** authentication was previously implemeted on initial configuration, there's not need to be applied in this PR.